### PR TITLE
Attempt to display raw error response if there is no body

### DIFF
--- a/server.js
+++ b/server.js
@@ -97,8 +97,8 @@ app.post('/token', function(req, res) {
         .end(function(err, postResponse) {
             if (err) {
                 var error = postResponse
-                    ? postResponse.body || "Unknown error"
-                    : "Unknown error";
+                    ? postResponse.body || err
+                    : err;
                 console.log("Error trading in authorization code:");
                 console.log(err);
                 res.redirect('/?error=' + JSON.stringify(error));
@@ -136,8 +136,8 @@ app.post('/refresh', function(req, res) {
         .send(payload)
         .end(function(err, postResponse) {
             var error = postResponse
-                    ? postResponse.body || "Unknown error"
-                    : "Unknown error";
+                    ? postResponse.body || err
+                    : err;
             if (err) {
                 console.log("Error trading in refresh token:");
                 console.log(err);


### PR DESCRIPTION
If the error object doesn't have a `body` type, attempt to display the entire error object. This can produce more meaningful error messages rather than "Unknown error". See image below.

![verbosity](https://cloud.githubusercontent.com/assets/1176292/16854623/cba7d708-49df-11e6-937b-457d9fabebb8.PNG)
